### PR TITLE
Corrected bug for Ubuntu 13.10

### DIFF
--- a/indicator-chars.py
+++ b/indicator-chars.py
@@ -74,7 +74,6 @@ class IndicatorChars:
 
         # Create menu
         menu = gtk.Menu()
-        self.ind.set_menu(menu)
         
         for charLine in charDef:
             charLine = unicode(charLine)
@@ -111,6 +110,7 @@ class IndicatorChars:
         menu.append(quit_item)
 
         # Show the menu
+        self.ind.set_menu(menu)
         menu.show_all()
 
     def on_char_click(self, widget, char):


### PR DESCRIPTION
indicator-chars was no longuer working in Ubuntu 13.10. This little change should correct the problem.
